### PR TITLE
apply debounce to onDisplayChanged

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -327,9 +327,9 @@ getSettings({"enabled": isChromeBook()}).then(settings => {
     if (settings.enabled) {
         getDisplays().then(tileWindows, reason => console.error(reason));
     
-        chrome.system.display.onDisplayChanged.addListener(() => {
+        chrome.system.display.onDisplayChanged.addListener(debounce(() => {
             getDisplays().then(tileWindows, reason => console.error(reason));
-        })
+        }, 250));
     
         chrome.windows.onCreated.addListener(tileWindows);
         chrome.windows.onRemoved.addListener(tileWindows);


### PR DESCRIPTION
When switching to an alternate account (multi-account) or virtual desktop, chrome.system.display.onDisplayChanged would be emitted multiple times in rapid succession. This would cause competing calls to getDisplay, generating extra Display entries in allDisplay with the same identifiers.
When attempting window manipulation with both instances with the same ID present, one copy would not be modified and reassert the stale settings, making it appear as the extension was not responding.